### PR TITLE
Add client side URL to CORS and Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec rails server -p $PORT

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:3000'
+    origins 'http://localhost:3000', 'https://sydney-paranormal.netlify.app'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Included the Netlify link to the permitted origins in the CORS file, and created a Procfile with a command that tells Heroku which server to load when the project gets deployed (this essentially prevents Heroku from crashing).